### PR TITLE
[fix] invalid header padding when auth token is passed with

### DIFF
--- a/midil/extensions/fastapi/middleware/auth_middleware.py
+++ b/midil/extensions/fastapi/middleware/auth_middleware.py
@@ -99,7 +99,7 @@ class BaseAuthMiddleware(BaseHTTPMiddleware):
                 raise HTTPException(
                     status_code=401, detail="Authorization header is missing"
                 )
-            token = request.headers["authorization"]
+            token = self._resolve_bearer_token(request.headers["authorization"])
 
             authorizer = await self.authorizer(request)
             claims = await authorizer.verify(token)
@@ -134,6 +134,20 @@ class BaseAuthMiddleware(BaseHTTPMiddleware):
             ```
         """
         raise NotImplementedError("Authorizer not implemented")
+
+    def _resolve_bearer_token(self, token: str) -> str:
+        """
+        Resolves the bearer token from the Authorization header.
+
+        Args:
+            token (str): The Authorization header value.
+
+        Returns:
+            str: The stripped token without "Bearer " prefix.
+        """
+        if token.startswith("Bearer "):
+            return token.replace("Bearer ", "")
+        return token
 
 
 class CognitoAuthMiddleware(BaseAuthMiddleware):


### PR DESCRIPTION
# Description
This PR is to resolve the "JWT verification failed: Invalid header padding" when the auth token is passed with "Bearer" prefix

# Details
- Added a resolver method to resolve all tokens passed to remove the "Bearer" prefix