### PR TITLE
docs(auth): add authentication documentation

### DIFF
--- a/docs/auth/cognito.md
+++ b/docs/auth/cognito.md
@@ -1,0 +1,300 @@
+---
+slug: /auth/cognito
+title: Cognito integration
+description: AWS Cognito authentication and authorization integration for midil-kit
+---
+
+# Cognito Integration
+
+The Cognito integration provides complete AWS Cognito support for both authentication (acquiring tokens) and authorization (validating tokens) in midil-kit applications.
+
+## Purpose
+
+This module implements:
+- **OAuth2 Client Credentials Flow**: For service-to-service authentication
+- **JWT Token Validation**: Using Cognito's JWKS (JSON Web Key Set) endpoint
+- **Automatic Token Caching**: With expiration handling and refresh logic
+- **Comprehensive Error Handling**: With Cognito-specific exception types
+
+## Public API
+
+The following classes and functions are exported from `midil.auth.cognito`:
+
+```python
+from midil.auth.cognito import (
+    CognitoClientCredentialsAuthenticator,  # For acquiring tokens
+    CognitoJWTAuthorizer,                   # For validating tokens
+    CognitoAuthenticationError,             # Auth-specific exceptions
+    CognitoAuthorizationError,              # AuthZ-specific exceptions
+)
+```
+
+## CognitoClientCredentialsAuthenticator
+
+Implements the OAuth2 client credentials flow for acquiring access tokens from Cognito.
+
+### Signature
+
+```python
+class CognitoClientCredentialsAuthenticator(AuthNProvider):
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        token_url: str,
+        scope: Optional[str] = None,
+    ):
+        # ...
+```
+
+### Behavior
+
+- **Token Caching**: Automatically caches tokens until expiration
+- **Concurrent Safety**: Uses asyncio locks to prevent race conditions
+- **Automatic Refresh**: Fetches new tokens when cached ones expire
+- **Basic Authentication**: Uses client credentials for token requests
+
+### Example Usage
+
+```python
+from midil.auth.cognito import CognitoClientCredentialsAuthenticator
+
+# Initialize authenticator
+authenticator = CognitoClientCredentialsAuthenticator(
+    client_id="your-app-client-id",
+    client_secret="your-app-client-secret",
+    token_url="https://your-domain.auth.us-east-1.amazoncognito.com/oauth2/token",
+    scope="read write"  # Optional
+)
+
+# Get authentication token
+token = await authenticator.get_token()
+print(f"Access token: {token.token}")
+print(f"Expires at: {token.expires_at_iso}")
+
+# Get headers for HTTP requests
+headers = await authenticator.get_headers()
+print(f"Authorization: {headers.authorization}")
+```
+
+## CognitoJWTAuthorizer
+
+Validates and decodes JWT tokens issued by AWS Cognito using the JWKS endpoint.
+
+### Signature
+
+```python
+class CognitoJWTAuthorizer(AuthZProvider):
+    def __init__(
+        self, 
+        user_pool_id: str, 
+        region: str, 
+        audience: Optional[str] = None
+    ) -> None:
+        # ...
+```
+
+### JWKS Behavior
+
+- **Automatic Key Fetching**: Retrieves signing keys from Cognito's JWKS endpoint
+- **Key Caching**: Caches keys for 15 minutes with automatic refresh
+- **Retry Logic**: Automatically retries key fetching on failures
+- **Concurrent Access**: Thread-safe key retrieval with asyncio locks
+
+### Example Usage
+
+```python
+from midil.auth.cognito import CognitoJWTAuthorizer, CognitoAuthorizationError
+
+# Initialize authorizer
+authorizer = CognitoJWTAuthorizer(
+    user_pool_id="us-east-1_ABC123DEF",
+    region="us-east-1",
+    audience="your-client-id"  # Optional, for audience validation
+)
+
+# Validate a JWT token
+try:
+    claims = await authorizer.verify("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...")
+    print(f"User ID: {claims.sub}")
+    print(f"Email: {claims.email}")
+    print(f"Name: {claims.name}")
+    print(f"Expires: {claims.expires_at()}")
+except CognitoAuthorizationError as e:
+    print(f"Token validation failed: {e}")
+```
+
+## Cognito-Specific Exceptions
+
+### CognitoAuthenticationError
+
+Raised when authentication with Cognito fails:
+
+```python
+from midil.auth.cognito import CognitoAuthenticationError
+
+try:
+    token = await authenticator.get_token()
+except CognitoAuthenticationError as e:
+    print(f"Authentication failed: {e}")
+    # Handle authentication failure
+```
+
+### CognitoAuthorizationError
+
+Raised when token validation fails:
+
+```python
+from midil.auth.cognito import CognitoAuthorizationError
+
+try:
+    claims = await authorizer.verify(token)
+except CognitoAuthorizationError as e:
+    print(f"Authorization failed: {e}")
+    # Handle authorization failure
+```
+
+## Configuration and Environment Mapping
+
+### Required Environment Variables
+
+```bash
+# Cognito User Pool Configuration
+COGNITO_USER_POOL_ID=us-east-1_ABC123DEF
+COGNITO_CLIENT_ID=your-app-client-id
+AWS_REGION=us-east-1
+
+# Optional: Client Secret (required for client credentials flow)
+COGNITO_CLIENT_SECRET=<REDACTED>
+```
+
+### Example .env Configuration
+
+```bash
+# .env file for development
+COGNITO_USER_POOL_ID=us-east-1_ABC123DEF
+COGNITO_CLIENT_ID=your-app-client-id
+COGNITO_CLIENT_SECRET=your-client-secret-here
+AWS_REGION=us-east-1
+
+# Token endpoint (constructed from domain)
+COGNITO_DOMAIN=your-domain.auth.us-east-1.amazoncognito.com
+```
+
+### Configuration in Code
+
+```python
+import os
+from midil.auth.cognito import CognitoClientCredentialsAuthenticator
+
+# Load from environment
+authenticator = CognitoClientCredentialsAuthenticator(
+    client_id=os.getenv("COGNITO_CLIENT_ID"),
+    client_secret=os.getenv("COGNITO_CLIENT_SECRET"),
+    token_url=f"https://{os.getenv('COGNITO_DOMAIN')}/oauth2/token",
+    scope=os.getenv("COGNITO_SCOPE", "read write")
+)
+```
+
+## Troubleshooting
+
+### Token Fetch Issues
+
+**Problem**: `CognitoAuthenticationError` when fetching tokens
+
+**Solutions**:
+1. Verify client credentials in Cognito User Pool
+2. Check network connectivity to Cognito
+3. Ensure proper IAM permissions for the client
+4. Validate token URL format
+
+```python
+# Debug token fetch
+try:
+    token = await authenticator.get_token()
+except CognitoAuthenticationError as e:
+    print(f"Token fetch failed: {e}")
+    # Check authenticator configuration
+    print(f"Client ID: {authenticator.client_id}")
+    print(f"Token URL: {authenticator.token_url}")
+```
+
+### JWKS Key Fetching Issues
+
+**Problem**: Signing key retrieval failures
+
+**Solutions**:
+1. Verify JWKS URL accessibility
+2. Check AWS region configuration
+3. Ensure proper network connectivity
+
+```python
+# Debug JWKS URL
+authorizer = CognitoJWTAuthorizer("us-east-1_ABC123DEF", "us-east-1")
+print(f"JWKS URL: {authorizer.jwks_url}")
+# Should be: https://cognito-idp.us-east-1.amazonaws.com/us-east-1_ABC123DEF/.well-known/jwks.json
+```
+
+### Audience Validation Issues
+
+**Problem**: Token validation fails due to audience mismatch
+
+**Solutions**:
+1. Ensure audience matches your client ID
+2. Check Cognito User Pool audience configuration
+3. Verify token was issued for the correct audience
+
+```python
+# Debug audience validation
+authorizer = CognitoJWTAuthorizer(
+    user_pool_id="us-east-1_ABC123DEF",
+    region="us-east-1",
+    audience="your-expected-client-id"  # Must match token audience
+)
+```
+
+### Clock Skew Issues
+
+**Problem**: Token validation fails due to time differences
+
+**Solutions**:
+1. Synchronize system clock with NTP
+2. Check timezone configuration
+3. Verify JWT `iat` and `exp` claims
+
+```python
+import datetime
+from datetime import timezone
+
+# Check system time
+now = datetime.datetime.now(timezone.utc)
+print(f"System time (UTC): {now.isoformat()}")
+
+# Check token expiration
+if claims.expires_at():
+    print(f"Token expires: {claims.expires_at().isoformat()}")
+    print(f"Time until expiry: {claims.expires_at() - now}")
+```
+
+## Where to Look in Code
+
+### Source Comments
+
+Key implementation details can be found in:
+
+- **Token Caching Logic**: `client_credentials_flow.py:31-49` <!-- source: midil-kit-main/midil/auth/cognito/client_credentials_flow.py:31-49 -->
+- **JWKS Key Fetching**: `jwt_authorizer.py:64-87` <!-- source: midil-kit-main/midil/auth/cognito/jwt_authorizer.py:64-87 -->
+- **JWT Validation Options**: `jwt_authorizer.py:101-113` <!-- source: midil-kit-main/midil/auth/cognito/jwt_authorizer.py:101-113 -->
+- **Error Handling**: `jwt_authorizer.py:119-129` <!-- source: midil-kit-main/midil/auth/cognito/jwt_authorizer.py:119-129 -->
+
+### Test Files
+
+Comprehensive test coverage available in:
+- `tests/auth/cognito/test_client_credentials_flow.py`
+- `tests/auth/cognito/test_jwt_authorizer.py`
+- `tests/auth/cognito/test_exceptions.py`
+
+<!-- source: midil-kit-main/midil/auth/cognito/__init__.py -->
+<!-- source: midil-kit-main/midil/auth/cognito/client_credentials_flow.py -->
+<!-- source: midil-kit-main/midil/auth/cognito/jwt_authorizer.py -->
+<!-- source: midil-kit-main/midil/auth/cognito/_exceptions.py -->

--- a/docs/auth/config.md
+++ b/docs/auth/config.md
@@ -1,0 +1,303 @@
+---
+slug: /auth/config
+title: Auth configuration
+description: Configuration management for the midil-kit authentication module
+---
+
+# Auth Configuration
+
+The auth module uses Pydantic models for type-safe configuration management with environment variable integration and validation.
+
+## Pydantic Model Fields
+
+### CognitoAuthConfig
+
+The main configuration model for Cognito authentication:
+
+```python
+from typing import Annotated, Literal, Optional, Union
+from pydantic import BaseModel, Field, SecretStr
+
+class CognitoAuthConfig(BaseModel):
+    type: Literal["cognito"] = "cognito"
+    user_pool_id: str = Field(..., description="Cognito User Pool ID")
+    client_id: str = Field(..., description="Cognito App Client ID")
+    client_secret: Optional[SecretStr] = Field(
+        None, description="Cognito App Client Secret (optional)"
+    )
+    region: str = Field(..., description="AWS region for Cognito")
+
+AuthConfig = Annotated[Union[CognitoAuthConfig], Field(discriminator="type")]
+```
+
+### Field Descriptions
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | `Literal["cognito"]` | Yes | Discriminator for auth type (defaults to "cognito") |
+| `user_pool_id` | `str` | Yes | AWS Cognito User Pool identifier |
+| `client_id` | `str` | Yes | Cognito App Client identifier |
+| `client_secret` | `Optional[SecretStr]` | No | App Client secret (required for client credentials flow) |
+| `region` | `str` | Yes | AWS region where Cognito is deployed |
+
+## Environment Variable Mapping
+
+### Recommended Environment Variables
+
+```bash
+# Required variables
+COGNITO_USER_POOL_ID=us-east-1_ABC123DEF
+COGNITO_CLIENT_ID=your-app-client-id
+AWS_REGION=us-east-1
+
+# Optional variables
+COGNITO_CLIENT_SECRET=your-client-secret-here
+```
+
+### Environment Variable Loading
+
+```python
+import os
+from midil.auth.config import CognitoAuthConfig
+
+# Load configuration from environment
+config = CognitoAuthConfig(
+    user_pool_id=os.getenv("COGNITO_USER_POOL_ID"),
+    client_id=os.getenv("COGNITO_CLIENT_ID"),
+    client_secret=os.getenv("COGNITO_CLIENT_SECRET"),
+    region=os.getenv("AWS_REGION", "us-east-1")
+)
+```
+
+### Using with Pydantic Settings
+
+For automatic environment variable loading, integrate with Pydantic Settings:
+
+```python
+from pydantic import BaseSettings
+from midil.auth.config import CognitoAuthConfig
+
+class Settings(BaseSettings):
+    cognito: CognitoAuthConfig
+    
+    class Config:
+        env_nested_delimiter = "__"
+
+# Load from environment with nested structure
+settings = Settings()
+cognito_config = settings.cognito
+```
+
+## Example .env Configuration
+
+### Development Environment
+
+```bash
+# .env.development
+COGNITO_USER_POOL_ID=us-east-1_ABC123DEF
+COGNITO_CLIENT_ID=dev-app-client-id
+COGNITO_CLIENT_SECRET=dev-client-secret-here
+AWS_REGION=us-east-1
+```
+
+### Production Environment
+
+```bash
+# .env.production
+COGNITO_USER_POOL_ID=us-east-1_PROD123ABC
+COGNITO_CLIENT_ID=prod-app-client-id
+COGNITO_CLIENT_SECRET=<REDACTED>
+AWS_REGION=us-east-1
+```
+
+### Testing Environment
+
+```bash
+# .env.testing
+COGNITO_USER_POOL_ID=us-east-1_TEST123DEF
+COGNITO_CLIENT_ID=test-app-client-id
+COGNITO_CLIENT_SECRET=test-client-secret
+AWS_REGION=us-east-1
+```
+
+## Configuration Validation
+
+### Type Validation
+
+Pydantic automatically validates field types:
+
+```python
+from midil.auth.config import CognitoAuthConfig
+from pydantic import ValidationError
+
+try:
+    config = CognitoAuthConfig(
+        user_pool_id="us-east-1_ABC123DEF",
+        client_id="valid-client-id",
+        region="us-east-1"
+    )
+    print("Configuration is valid")
+except ValidationError as e:
+    print(f"Configuration validation failed: {e}")
+```
+
+### Required Field Validation
+
+```python
+# This will raise ValidationError
+try:
+    config = CognitoAuthConfig(
+        client_id="valid-client-id"
+        # Missing required fields: user_pool_id, region
+    )
+except ValidationError as e:
+    print(f"Missing required fields: {e}")
+```
+
+### Secret String Handling
+
+The `client_secret` field uses `SecretStr` for secure handling:
+
+```python
+from midil.auth.config import CognitoAuthConfig
+
+config = CognitoAuthConfig(
+    user_pool_id="us-east-1_ABC123DEF",
+    client_id="valid-client-id",
+    client_secret="secret-value",
+    region="us-east-1"
+)
+
+# Access secret value
+secret_value = config.client_secret.get_secret_value()
+print(f"Secret: {secret_value}")
+
+# Secret is not displayed in string representation
+print(f"Config: {config}")  # client_secret will be hidden
+```
+
+## Deployment Notes
+
+### Secret Management
+
+For production deployments, use secure secret management:
+
+#### AWS Secrets Manager
+
+```python
+import boto3
+from midil.auth.config import CognitoAuthConfig
+
+def load_config_from_secrets_manager(secret_name: str) -> CognitoAuthConfig:
+    client = boto3.client('secretsmanager')
+    response = client.get_secret_value(SecretId=secret_name)
+    secret_data = json.loads(response['SecretString'])
+    
+    return CognitoAuthConfig(**secret_data)
+```
+
+#### Azure Key Vault
+
+```python
+from azure.keyvault.secrets import SecretClient
+from midil.auth.config import CognitoAuthConfig
+
+def load_config_from_key_vault(vault_url: str) -> CognitoAuthConfig:
+    client = SecretClient(vault_url=vault_url, credential=credential)
+    
+    return CognitoAuthConfig(
+        user_pool_id=client.get_secret("cognito-user-pool-id").value,
+        client_id=client.get_secret("cognito-client-id").value,
+        client_secret=client.get_secret("cognito-client-secret").value,
+        region=client.get_secret("aws-region").value
+    )
+```
+
+#### Environment-Specific Configuration
+
+```python
+import os
+from midil.auth.config import CognitoAuthConfig
+
+def get_auth_config() -> CognitoAuthConfig:
+    environment = os.getenv("ENVIRONMENT", "development")
+    
+    if environment == "production":
+        # Load from secret manager
+        return load_config_from_secrets_manager("prod/cognito-config")
+    elif environment == "staging":
+        # Load from environment variables
+        return CognitoAuthConfig(
+            user_pool_id=os.getenv("COGNITO_USER_POOL_ID"),
+            client_id=os.getenv("COGNITO_CLIENT_ID"),
+            client_secret=os.getenv("COGNITO_CLIENT_SECRET"),
+            region=os.getenv("AWS_REGION")
+        )
+    else:
+        # Development - load from .env file
+        from dotenv import load_dotenv
+        load_dotenv()
+        
+        return CognitoAuthConfig(
+            user_pool_id=os.getenv("COGNITO_USER_POOL_ID"),
+            client_id=os.getenv("COGNITO_CLIENT_ID"),
+            client_secret=os.getenv("COGNITO_CLIENT_SECRET"),
+            region=os.getenv("AWS_REGION")
+        )
+```
+
+### Configuration Caching
+
+For high-performance applications, consider caching configuration:
+
+```python
+from functools import lru_cache
+from midil.auth.config import CognitoAuthConfig
+
+@lru_cache(maxsize=1)
+def get_cached_auth_config() -> CognitoAuthConfig:
+    """Cache configuration to avoid repeated loading."""
+    return get_auth_config()
+
+# Use cached configuration
+config = get_cached_auth_config()
+```
+
+## Integration Examples
+
+### FastAPI Integration
+
+```python
+from fastapi import FastAPI, Depends
+from midil.auth.config import CognitoAuthConfig
+
+app = FastAPI()
+
+def get_auth_config() -> CognitoAuthConfig:
+    return CognitoAuthConfig(
+        user_pool_id=os.getenv("COGNITO_USER_POOL_ID"),
+        client_id=os.getenv("COGNITO_CLIENT_ID"),
+        client_secret=os.getenv("COGNITO_CLIENT_SECRET"),
+        region=os.getenv("AWS_REGION")
+    )
+
+@app.get("/")
+async def root(auth_config: CognitoAuthConfig = Depends(get_auth_config)):
+    return {"user_pool_id": auth_config.user_pool_id}
+```
+
+### Django Integration
+
+```python
+# settings.py
+from midil.auth.config import CognitoAuthConfig
+
+COGNITO_CONFIG = CognitoAuthConfig(
+    user_pool_id=os.getenv("COGNITO_USER_POOL_ID"),
+    client_id=os.getenv("COGNITO_CLIENT_ID"),
+    client_secret=os.getenv("COGNITO_CLIENT_SECRET"),
+    region=os.getenv("AWS_REGION")
+)
+```
+
+<!-- source: midil-kit-main/midil/auth/config.py -->

--- a/docs/auth/exceptions.md
+++ b/docs/auth/exceptions.md
@@ -1,0 +1,435 @@
+---
+slug: /auth/exceptions
+title: Auth exceptions
+description: Exception hierarchy and error handling for the midil-kit authentication module
+---
+
+# Auth Exceptions
+
+The auth module provides a comprehensive exception hierarchy for handling authentication and authorization errors with clear error types and HTTP status code mapping.
+
+## Exception Hierarchy
+
+The exception hierarchy follows a clear inheritance pattern:
+
+```
+BaseAuthError
+├── AuthenticationError
+│   └── CognitoAuthenticationError
+└── AuthorizationError
+    └── CognitoAuthorizationError
+```
+
+### BaseAuthError
+
+The root exception class for all authentication and authorization errors.
+
+```python
+class BaseAuthError(Exception):
+    """Base exception for all authentication and authorization errors."""
+    pass
+```
+
+**Usage**:
+```python
+from midil.auth.exceptions import BaseAuthError 
+
+try:
+    # Some auth operation
+    pass
+except BaseAuthError as e:
+    print(f"Authentication/Authorization error: {e}")
+```
+
+### AuthenticationError
+
+Raised when authentication (verifying identity) fails.
+
+```python
+class AuthenticationError(BaseAuthError):
+    """Exception raised when authentication fails."""
+    pass
+```
+
+**Common Scenarios**:
+- Invalid credentials
+- Token acquisition failures
+- Network errors during authentication
+- Client configuration errors
+
+**Usage**:
+```python
+from midil.auth.exceptions import AuthenticationError
+
+try:
+    token = await authenticator.get_token()
+except AuthenticationError as e:
+    print(f"Authentication failed: {e}")
+    # Handle authentication failure
+```
+
+### AuthorizationError
+
+Raised when authorization (validating permissions) fails.
+
+```python
+class AuthorizationError(BaseAuthError):
+    """Exception raised when authorization fails."""
+    pass
+```
+
+**Common Scenarios**:
+- Invalid or expired tokens
+- Insufficient permissions
+- Token validation failures
+- JWT signature verification errors
+
+**Usage**:
+```python
+from midil.auth.exceptions import AuthorizationError
+
+try:
+    claims = await authorizer.verify(token)
+except AuthorizationError as e:
+    print(f"Authorization failed: {e}")
+    # Handle authorization failure
+```
+
+## Provider-Specific Exceptions
+
+### CognitoAuthenticationError
+
+Cognito-specific authentication errors.
+
+```python
+from midil.auth.cognito._exceptions import CognitoAuthenticationError
+
+class CognitoAuthenticationError(AuthenticationError):
+    """Exception raised when authentication with Cognito fails."""
+    pass
+```
+
+**Common Scenarios**:
+- Invalid client credentials
+- Cognito service unavailable
+- Network connectivity issues
+- Invalid token endpoint
+
+### CognitoAuthorizationError
+
+Cognito-specific authorization errors.
+
+```python
+from midil.auth.cognito._exceptions import CognitoAuthorizationError
+
+class CognitoAuthorizationError(AuthorizationError):
+    """Exception raised when authorization with Cognito fails."""
+    pass
+```
+
+**Common Scenarios**:
+- Invalid JWT signature
+- Expired tokens
+- Invalid audience
+- JWKS key fetch failures
+
+## HTTP Status Code Mapping
+
+### Suggested HTTP Status Mapping
+
+| Exception Type | HTTP Status | Description |
+|----------------|-------------|-------------|
+| `AuthenticationError` | `401 Unauthorized` | Authentication failed |
+| `AuthorizationError` | `403 Forbidden` | Authorization failed |
+| `CognitoAuthenticationError` | `401 Unauthorized` | Cognito auth failed |
+| `CognitoAuthorizationError` | `403 Forbidden` | Cognito authz failed |
+
+### FastAPI Exception Handler Examples
+
+```python
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from midil.auth.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    CognitoAuthenticationError,
+    CognitoAuthorizationError
+)
+
+app = FastAPI()
+
+@app.exception_handler(AuthenticationError)
+async def authentication_exception_handler(request: Request, exc: AuthenticationError):
+    return JSONResponse(
+        status_code=401,
+        content={
+            "error": "authentication_failed",
+            "message": str(exc),
+            "type": "AuthenticationError"
+        }
+    )
+
+@app.exception_handler(AuthorizationError)
+async def authorization_exception_handler(request: Request, exc: AuthorizationError):
+    return JSONResponse(
+        status_code=403,
+        content={
+            "error": "authorization_failed",
+            "message": str(exc),
+            "type": "AuthorizationError"
+        }
+    )
+
+@app.exception_handler(CognitoAuthenticationError)
+async def cognito_auth_exception_handler(request: Request, exc: CognitoAuthenticationError):
+    return JSONResponse(
+        status_code=401,
+        content={
+            "error": "cognito_authentication_failed",
+            "message": str(exc),
+            "type": "CognitoAuthenticationError"
+        }
+    )
+
+@app.exception_handler(CognitoAuthorizationError)
+async def cognito_authz_exception_handler(request: Request, exc: CognitoAuthorizationError):
+    return JSONResponse(
+        status_code=403,
+        content={
+            "error": "cognito_authorization_failed",
+            "message": str(exc),
+            "type": "CognitoAuthorizationError"
+        }
+    )
+```
+
+### Django Exception Handling
+
+```python
+from django.http import JsonResponse
+from midil.auth.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    CognitoAuthenticationError,
+    CognitoAuthorizationError
+)
+
+def handle_auth_exceptions(get_response):
+    def middleware(request):
+        try:
+            response = get_response(request)
+            return response
+        except AuthenticationError as e:
+            return JsonResponse(
+                {"error": "authentication_failed", "message": str(e)},
+                status=401
+            )
+        except AuthorizationError as e:
+            return JsonResponse(
+                {"error": "authorization_failed", "message": str(e)},
+                status=403
+            )
+        except CognitoAuthenticationError as e:
+            return JsonResponse(
+                {"error": "cognito_authentication_failed", "message": str(e)},
+                status=401
+            )
+        except CognitoAuthorizationError as e:
+            return JsonResponse(
+                {"error": "cognito_authorization_failed", "message": str(e)},
+                status=403
+            )
+    
+    return middleware
+```
+
+## Mapping Provider-Specific Errors
+
+### Cognito Error Mapping
+
+```python
+from midil.auth.cognito._exceptions import (
+    CognitoAuthenticationError,
+    CognitoAuthorizationError
+)
+from midil.auth.exceptions import AuthenticationError, AuthorizationError
+
+def map_cognito_errors(func):
+    """Decorator to map Cognito-specific errors to generic auth errors."""
+    async def wrapper(*args, **kwargs):
+        try:
+            return await func(*args, **kwargs)
+        except CognitoAuthenticationError as e:
+            # Map to generic authentication error
+            raise AuthenticationError(f"Cognito authentication failed: {e}") from e
+        except CognitoAuthorizationError as e:
+            # Map to generic authorization error
+            raise AuthorizationError(f"Cognito authorization failed: {e}") from e
+    
+    return wrapper
+
+# Usage
+@map_cognito_errors
+async def authenticate_user(token: str):
+    # This will map Cognito errors to generic auth errors
+    return await cognito_authorizer.verify(token)
+```
+
+### Custom Error Mapping
+
+```python
+from midil.auth.exceptions import AuthenticationError, AuthorizationError
+
+class ErrorMapper:
+    @staticmethod
+    def map_http_error_to_auth_error(status_code: int, message: str):
+        """Map HTTP status codes to appropriate auth exceptions."""
+        if status_code == 401:
+            return AuthenticationError(f"HTTP 401: {message}")
+        elif status_code == 403:
+            return AuthorizationError(f"HTTP 403: {message}")
+        else:
+            return AuthenticationError(f"HTTP {status_code}: {message}")
+    
+    @staticmethod
+    def map_jwt_error_to_auth_error(jwt_error: Exception):
+        """Map JWT library errors to auth exceptions."""
+        if "expired" in str(jwt_error).lower():
+            return AuthorizationError("Token has expired")
+        elif "signature" in str(jwt_error).lower():
+            return AuthorizationError("Invalid token signature")
+        else:
+            return AuthorizationError(f"JWT validation failed: {jwt_error}")
+```
+
+## Error Handling Best Practices
+
+### Structured Error Responses
+
+```python
+from dataclasses import dataclass
+from typing import Optional, Dict, Any
+
+@dataclass
+class AuthErrorResponse:
+    error_code: str
+    message: str
+    details: Optional[Dict[str, Any]] = None
+    timestamp: Optional[str] = None
+
+def create_error_response(exception: BaseAuthError) -> AuthErrorResponse:
+    """Create a structured error response from an auth exception."""
+    return AuthErrorResponse(
+        error_code=exception.__class__.__name__,
+        message=str(exception),
+        timestamp=datetime.utcnow().isoformat()
+    )
+```
+
+### Logging Integration
+
+```python
+import logging
+from midil.auth.exceptions import BaseAuthError
+
+logger = logging.getLogger(__name__)
+
+def handle_auth_error(exception: BaseAuthError, context: Dict[str, Any] = None):
+    """Handle auth errors with proper logging."""
+    logger.error(
+        f"Auth error: {exception}",
+        extra={
+            "error_type": exception.__class__.__name__,
+            "context": context or {}
+        }
+    )
+    
+    # Log additional context for debugging
+    if isinstance(exception, CognitoAuthenticationError):
+        logger.debug("Cognito authentication error details", extra={"context": context})
+    elif isinstance(exception, CognitoAuthorizationError):
+        logger.debug("Cognito authorization error details", extra={"context": context})
+```
+
+### Retry Logic with Exceptions
+
+```python
+from tenacity import retry, stop_after_attempt, wait_exponential
+from midil.auth.exceptions import AuthenticationError, AuthorizationError
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=4, max=10),
+    retry=retry_if_exception_type(AuthenticationError)
+)
+async def authenticate_with_retry(authenticator, credentials):
+    """Authenticate with retry logic for transient errors."""
+    try:
+        return await authenticator.get_token()
+    except AuthenticationError as e:
+        # Only retry on transient authentication errors
+        if "network" in str(e).lower() or "timeout" in str(e).lower():
+            raise  # Retry
+        else:
+            raise  # Don't retry on permanent errors
+```
+
+## Testing Exception Handling
+
+### Unit Tests for Exceptions
+
+```python
+import pytest
+from midil.auth.exceptions import (
+    BaseAuthError,
+    AuthenticationError,
+    AuthorizationError
+)
+
+def test_exception_hierarchy():
+    """Test that exception hierarchy is correct."""
+    assert issubclass(AuthenticationError, BaseAuthError)
+    assert issubclass(AuthorizationError, BaseAuthError)
+    assert not issubclass(AuthenticationError, AuthorizationError)
+
+def test_exception_instantiation():
+    """Test that exceptions can be instantiated."""
+    auth_error = AuthenticationError("Auth failed")
+    authz_error = AuthorizationError("Authz failed")
+    
+    assert str(auth_error) == "Auth failed"
+    assert str(authz_error) == "Authz failed"
+
+def test_exception_chaining():
+    """Test exception chaining."""
+    original_error = ValueError("Original error")
+    
+    try:
+        raise original_error
+    except ValueError as e:
+        auth_error = AuthenticationError("Auth failed") from e
+        assert auth_error.__cause__ == original_error
+```
+
+### Integration Tests
+
+```python
+@pytest.mark.asyncio
+async def test_cognito_error_mapping():
+    """Test that Cognito errors are properly mapped."""
+    from midil.auth.cognito import CognitoClientCredentialsAuthenticator
+    from midil.auth.cognito._exceptions import CognitoAuthenticationError
+    
+    authenticator = CognitoClientCredentialsAuthenticator(
+        client_id="invalid-id",
+        client_secret="invalid-secret",
+        token_url="https://invalid-url.com/token"
+    )
+    
+    with pytest.raises(CognitoAuthenticationError):
+        await authenticator.get_token()
+```
+
+<!-- source: midil-kit-main/midil/auth/exceptions.py -->
+<!-- source: midil-kit-main/midil/auth/cognito/_exceptions.py -->
+<!-- source: midil-kit-main/tests/auth/test_exceptions.py -->

--- a/docs/auth/index.md
+++ b/docs/auth/index.md
@@ -1,0 +1,203 @@
+---
+slug: /auth
+title: Authentication (auth)
+description: Complete authentication and authorization module for midil-kit with Cognito integration
+---
+
+# Authentication (auth)
+
+The `auth` module provides a comprehensive authentication and authorization system for midil-kit applications, with built-in support for AWS Cognito integration and extensible interfaces for custom authentication providers.
+
+## Overview
+
+The authentication module is designed around two core concepts:
+- **Authentication (AuthN)**: Verifying user identity and acquiring access tokens
+- **Authorization (AuthZ)**: Validating tokens and extracting user claims
+
+The module provides both concrete implementations (Cognito) and abstract interfaces for building custom authentication solutions.
+
+## File Tree
+
+```
+auth/
+├── __init__.py                 # Main exports
+├── config.py                   # Configuration models
+├── exceptions.py               # Base exception classes
+├── cognito/                    # AWS Cognito integration
+│   ├── __init__.py
+│   ├── client_credentials_flow.py  # OAuth2 client credentials flow
+│   ├── jwt_authorizer.py           # JWT token validation
+│   └── _exceptions.py              # Cognito-specific exceptions
+└── interfaces/                 # Abstract interfaces
+    ├── __init__.py
+    ├── authenticator.py        # AuthN provider interface
+    ├── authorizer.py           # AuthZ provider interface
+    └── models.py               # Data models
+```
+
+## Quick Start
+
+### Installation
+
+The auth module is part of midil-kit. Install dependencies:
+
+```bash
+pip install midil-kit
+# or with poetry
+poetry add midil-kit
+```
+
+### Running Tests
+
+```bash
+# Run all auth tests
+pytest tests/auth/
+
+# Run specific test files
+pytest tests/auth/cognito/test_client_credentials_flow.py
+pytest tests/auth/cognito/test_jwt_authorizer.py
+pytest tests/auth/interfaces/test_authenticator.py
+```
+
+## How-to Examples
+
+### Validate a JWT Token
+
+```python
+from midil.auth.cognito import CognitoJWTAuthorizer
+
+# Initialize the authorizer
+authorizer = CognitoJWTAuthorizer(
+    user_pool_id="us-east-1_ABC123DEF",
+    region="us-east-1",
+    audience="your-client-id"  # Optional
+)
+
+# Validate a token
+try:
+    claims = await authorizer.verify("your-jwt-token")
+    print(f"User: {claims.sub}, Email: {claims.email}")
+except CognitoAuthorizationError as e:
+    print(f"Token validation failed: {e}")
+```
+
+### Get Outbound Authentication Token
+
+```python
+from midil.auth.cognito import CognitoClientCredentialsAuthenticator
+
+# Initialize the authenticator
+authenticator = CognitoClientCredentialsAuthenticator(
+    client_id="your-client-id",
+    client_secret="your-client-secret",
+    token_url="https://your-domain.auth.region.amazoncognito.com/oauth2/token",
+    scope="read write"  # Optional
+)
+
+# Get authentication headers for outbound requests
+headers = await authenticator.get_headers()
+# Use headers.authorization in your HTTP requests
+```
+
+## Contents
+
+### [Cognito Integration](./cognito.md)
+Complete AWS Cognito integration including:
+- OAuth2 client credentials flow for service-to-service authentication
+- JWT token validation with JWKS support
+- Automatic token caching and refresh
+- Comprehensive error handling
+
+### [Auth Interfaces](./interfaces.md)
+Abstract interfaces for building custom authentication:
+- `AuthNProvider` for authentication implementations
+- `AuthZProvider` for authorization implementations
+- Data models for tokens and claims
+- Extensible design patterns
+
+### [Configuration](./config.md)
+Configuration management with Pydantic models:
+- Environment variable mapping
+- Type validation and defaults
+- Secret management integration
+
+### [Exception Handling](./exceptions.md)
+Comprehensive exception hierarchy:
+- Base authentication and authorization errors
+- Provider-specific exception classes
+- HTTP status code mapping guidance
+
+## Configuration Summary
+
+The auth module uses Pydantic models for configuration. Map these fields to environment variables:
+
+| Field | Environment Variable | Description | Required |
+|-------|---------------------|-------------|----------|
+| `user_pool_id` | `COGNITO_USER_POOL_ID` | Cognito User Pool ID | Yes |
+| `client_id` | `COGNITO_CLIENT_ID` | Cognito App Client ID | Yes |
+| `client_secret` | `COGNITO_CLIENT_SECRET` | App Client Secret | No* |
+| `region` | `AWS_REGION` | AWS region | Yes |
+
+*Required for client credentials flow
+
+### Example Environment Configuration
+
+```bash
+# .env file
+COGNITO_USER_POOL_ID=us-east-1_ABC123DEF
+COGNITO_CLIENT_ID=your-client-id
+COGNITO_CLIENT_SECRET=<REDACTED>
+AWS_REGION=us-east-1
+```
+
+## Troubleshooting
+
+### 1. Token Fetch Failures
+- **Issue**: `CognitoAuthenticationError` when fetching tokens
+- **Solutions**:
+  - Verify client credentials are correct
+  - Check network connectivity to Cognito
+  - Ensure client has proper permissions in Cognito User Pool
+  - Verify token URL format: `https://{domain}.auth.{region}.amazoncognito.com/oauth2/token`
+
+### 2. JWT Validation Errors
+- **Issue**: `CognitoAuthorizationError` during token validation
+- **Solutions**:
+  - Check token hasn't expired
+  - Verify audience matches your client ID
+  - Ensure issuer matches your Cognito User Pool
+  - Check system clock synchronization (JWT uses UTC timestamps)
+
+### 3. JWKS Key Fetching Issues
+- **Issue**: Signing key retrieval failures
+- **Solutions**:
+  - Verify JWKS URL is accessible: `https://cognito-idp.{region}.amazonaws.com/{user_pool_id}/.well-known/jwks.json`
+  - Check network connectivity
+  - Review AWS region configuration
+
+## Security Notes
+
+- **Token Storage**: Never store tokens in plain text. Use secure storage mechanisms.
+- **Client Secrets**: Store client secrets in environment variables or secret managers (AWS Secrets Manager, Azure Key Vault).
+- **HTTPS Only**: Always use HTTPS for token endpoints and JWKS URLs.
+- **Token Expiration**: Implement proper token refresh logic to avoid expired token usage.
+- **Audience Validation**: Always validate token audience to prevent token misuse.
+
+## Maintainers
+
+*Maintainer information to be added by repository owners*
+
+## Missing/Ambiguous Info
+
+The following information requires confirmation from repository maintainers:
+
+1. **Exact CLI Commands**: No CLI commands found for auth module testing
+2. **Example Token Formats**: Specific JWT token examples not found in codebase
+3. **Secret Management**: Integration details with specific secret managers not documented
+4. **Maintainer Contact**: GitHub handles or contact information not found
+5. **Migration Guide**: No migration documentation found for version upgrades
+6. **Performance Metrics**: No performance benchmarks or optimization guidelines found
+
+<!-- source: midil-kit-main/midil/auth/__init__.py -->
+<!-- source: midil-kit-main/midil/auth/config.py -->
+<!-- source: midil-kit-main/midil/auth/exceptions.py -->

--- a/docs/auth/interfaces.md
+++ b/docs/auth/interfaces.md
@@ -1,0 +1,337 @@
+---
+slug: /auth/interfaces
+title: Auth interfaces
+description: Abstract interfaces for authentication and authorization in midil-kit
+---
+
+# Auth Interfaces
+
+The interfaces module provides abstract base classes and data models for building custom authentication and authorization solutions in midil-kit applications.
+
+## Purpose
+
+This module defines the core contracts for:
+- **Authentication Providers**: For acquiring and managing access tokens
+- **Authorization Providers**: For validating and decoding tokens
+- **Data Models**: Standardized token and claim representations
+- **Extensibility**: Clean abstractions for custom implementations
+
+## File Tree
+
+```
+interfaces/
+├── __init__.py          # Main exports
+├── authenticator.py     # AuthN provider interface
+├── authorizer.py        # AuthZ provider interface
+└── models.py            # Data models and mixins
+```
+
+## AuthNProvider and AuthZProvider
+
+### AuthNProvider Interface
+
+Abstract base class for authentication clients that acquire and manage access tokens.
+
+```python
+from abc import ABC, abstractmethod
+from midil.auth.interfaces.models import AuthNToken, AuthNHeaders
+
+class AuthNProvider(ABC):
+    """Abstract base class for authentication clients that acquire and manage access tokens."""
+    
+    @abstractmethod
+    async def get_token(self) -> AuthNToken:
+        """Acquire a new access token from the authentication provider."""
+        pass
+
+    @abstractmethod
+    async def get_headers(self) -> AuthNHeaders:
+        """Return authentication headers suitable for making authorized HTTP requests."""
+        pass
+```
+
+### AuthZProvider Interface
+
+Abstract base class for authorization providers that validate and decode tokens.
+
+```python
+from abc import ABC, abstractmethod
+from midil.auth.interfaces.models import AuthZTokenClaims
+
+class AuthZProvider(ABC):
+    """Abstract base class for authentication authorizers that validate and decode tokens."""
+    
+    @abstractmethod
+    async def verify(self, token: str) -> AuthZTokenClaims:
+        """Validate and decode a token, returning the claims."""
+        pass
+```
+
+### Usage Examples
+
+#### Custom Authentication Provider
+
+```python
+from midil.auth.interfaces import AuthNProvider
+from midil.auth.interfaces.models import AuthNToken, AuthNHeaders
+
+class CustomAuthProvider(AuthNProvider):
+    def __init__(self, api_key: str, base_url: str):
+        self.api_key = api_key
+        self.base_url = base_url
+    
+    async def get_token(self) -> AuthNToken:
+        # Implement your custom token acquisition logic
+        response = await self._make_request("/auth/token")
+        return AuthNToken(
+            token=response["access_token"],
+            expires_at_iso=response["expires_at"]
+        )
+    
+    async def get_headers(self) -> AuthNHeaders:
+        token = await self.get_token()
+        return AuthNHeaders(
+            authorization=f"Bearer {token.token}",
+            content_type="application/json"
+        )
+```
+
+#### Custom Authorization Provider
+
+```python
+from midil.auth.interfaces import AuthZProvider
+from midil.auth.interfaces.models import AuthZTokenClaims
+
+class CustomAuthZProvider(AuthZProvider):
+    def __init__(self, secret_key: str):
+        self.secret_key = secret_key
+    
+    async def verify(self, token: str) -> AuthZTokenClaims:
+        # Implement your custom token validation logic
+        decoded = self._decode_token(token)
+        return AuthZTokenClaims(
+            token=token,
+            sub=decoded["sub"],
+            exp=decoded["exp"]
+        )
+```
+
+## Models
+
+### AuthNToken
+
+Represents an authentication token with expiration handling.
+
+```python
+class AuthNToken(ExpirableTokenMixin):
+    expires_at_iso: Optional[str] = None
+    
+    def expires_at(self) -> Optional[datetime]:
+        return isoparse(self.expires_at_iso) if self.expires_at_iso else None
+```
+
+**Usage Example**:
+```python
+from midil.auth.interfaces.models import AuthNToken
+from datetime import datetime, timezone, timedelta
+
+# Create a token with expiration
+token = AuthNToken(
+    token="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
+    expires_at_iso=(datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+)
+
+# Check if token is expired
+if token.expired:
+    print("Token has expired")
+else:
+    print(f"Token expires at: {token.expires_at()}")
+```
+
+### AuthNHeaders
+
+Standardized authentication headers for HTTP requests.
+
+```python
+class AuthNHeaders(BaseModel):
+    authorization: str = Field(..., alias="Authorization")
+    accept: str = Field(default="application/json", alias="Accept")
+    content_type: str = Field(default="application/json", alias="Content-Type")
+```
+
+**Usage Example**:
+```python
+from midil.auth.interfaces.models import AuthNHeaders
+
+# Create headers for API request
+headers = AuthNHeaders(
+    authorization="Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
+    content_type="application/json"
+)
+
+# Use in HTTP request
+import httpx
+async with httpx.AsyncClient() as client:
+    response = await client.get(
+        "https://api.example.com/data",
+        headers=headers.dict(by_alias=True)
+    )
+```
+
+### AuthZTokenClaims
+
+Base model for token claims with expiration handling.
+
+```python
+class AuthZTokenClaims(ExpirableTokenMixin):
+    sub: str  # Subject (user ID)
+    exp: int  # Expiration timestamp (epoch)
+    
+    def expires_at(self) -> datetime:
+        return datetime.fromtimestamp(self.exp, tz=timezone.utc)
+```
+
+**Usage Example**:
+```python
+from midil.auth.interfaces.models import AuthZTokenClaims
+from datetime import datetime, timezone
+
+# Create claims from decoded JWT
+claims = AuthZTokenClaims(
+    token="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
+    sub="user123",
+    exp=int(datetime.now(timezone.utc).timestamp()) + 3600
+)
+
+# Access user information
+print(f"User ID: {claims.sub}")
+print(f"Expires at: {claims.expires_at()}")
+print(f"Is expired: {claims.expired}")
+```
+
+### ExpirableTokenMixin
+
+Mixin providing expiration logic for tokens.
+
+```python
+class ExpirableTokenMixin(BaseModel):
+    _time_buffer: timedelta = PrivateAttr(default_factory=lambda: timedelta(minutes=5))
+    token: str
+    refresh_token: Optional[str] = None
+    
+    def expires_at(self) -> Optional[datetime]:
+        raise NotImplementedError("Subclasses must implement expires_at()")
+    
+    @property
+    def expired(self) -> bool:
+        # Returns True if token is expired (with 5-minute buffer)
+        pass
+    
+    @property
+    def should_refresh(self) -> bool:
+        # Returns True if token should be refreshed
+        pass
+```
+
+## Testing Tips for Interfaces
+
+### Mock Implementations
+
+Create mock implementations for testing:
+
+```python
+from unittest.mock import AsyncMock
+from midil.auth.interfaces import AuthNProvider, AuthZProvider
+from midil.auth.interfaces.models import AuthNToken, AuthZTokenClaims
+
+class MockAuthNProvider(AuthNProvider):
+    def __init__(self, token_value: str = "mock-token"):
+        self.token_value = token_value
+    
+    async def get_token(self) -> AuthNToken:
+        return AuthNToken(token=self.token_value)
+    
+    async def get_headers(self) -> AuthNHeaders:
+        return AuthNHeaders(authorization=f"Bearer {self.token_value}")
+
+class MockAuthZProvider(AuthZProvider):
+    def __init__(self, should_validate: bool = True):
+        self.should_validate = should_validate
+    
+    async def verify(self, token: str) -> AuthZTokenClaims:
+        if not self.should_validate:
+            raise ValueError("Invalid token")
+        
+        return AuthZTokenClaims(
+            token=token,
+            sub="test-user",
+            exp=int(datetime.now(timezone.utc).timestamp()) + 3600
+        )
+```
+
+### Testing Custom Implementations
+
+```python
+import pytest
+from midil.auth.interfaces import AuthNProvider, AuthZProvider
+
+@pytest.mark.asyncio
+async def test_custom_auth_provider():
+    provider = CustomAuthProvider("api-key", "https://api.example.com")
+    
+    # Test token acquisition
+    token = await provider.get_token()
+    assert isinstance(token, AuthNToken)
+    assert token.token is not None
+    
+    # Test header generation
+    headers = await provider.get_headers()
+    assert headers.authorization.startswith("Bearer ")
+
+@pytest.mark.asyncio
+async def test_custom_authz_provider():
+    provider = CustomAuthZProvider("secret-key")
+    
+    # Test valid token
+    claims = await provider.verify("valid-token")
+    assert isinstance(claims, AuthZTokenClaims)
+    assert claims.sub == "test-user"
+    
+    # Test invalid token
+    with pytest.raises(ValueError):
+        await provider.verify("invalid-token")
+```
+
+## Where to Look in Code
+
+### Source Comments
+
+Key implementation details can be found in:
+
+- **AuthNProvider Interface**: `authenticator.py:5-42` <!-- source: midil-kit-main/midil/auth/interfaces/authenticator.py:5-42 -->
+- **AuthZProvider Interface**: `authorizer.py:5-21` <!-- source: midil-kit-main/midil/auth/interfaces/authorizer.py:5-21 -->
+- **ExpirableTokenMixin**: `models.py:7-25` <!-- source: midil-kit-main/midil/auth/interfaces/models.py:7-25 -->
+- **AuthNToken Implementation**: `models.py:27-32` <!-- source: midil-kit-main/midil/auth/interfaces/models.py:27-32 -->
+- **AuthZTokenClaims Implementation**: `models.py:45-51` <!-- source: midil-kit-main/midil/auth/interfaces/models.py:45-51 -->
+
+### Test Files
+
+Comprehensive test coverage available in:
+- `tests/auth/interfaces/test_authenticator.py`
+- `tests/auth/interfaces/test_authorizer.py`
+- `tests/auth/interfaces/test_models.py`
+
+## Missing Info
+
+The following information requires clarification:
+
+1. **Custom Provider Examples**: No concrete examples of custom implementations found in codebase
+2. **Interface Versioning**: No versioning strategy documented for interface changes
+3. **Performance Guidelines**: No performance recommendations for custom implementations
+4. **Error Handling Patterns**: No standardized error handling patterns for custom providers
+5. **Configuration Integration**: No guidance on integrating custom providers with configuration system
+
+<!-- source: midil-kit-main/midil/auth/interfaces/__init__.py -->
+<!-- source: midil-kit-main/midil/auth/interfaces/authenticator.py -->
+<!-- source: midil-kit-main/midil/auth/interfaces/authorizer.py -->
+<!-- source: midil-kit-main/midil/auth/interfaces/models.py -->


### PR DESCRIPTION
## Summary
Add authentication documentation under `docs/auth/`:
- docs/auth/index.md
- docs/auth/cognito.md
- docs/auth/interfaces.md

## How to preview locally
1. npm ci
2. npm run start
3. Open http://localhost:3000 and navigate to Auth → Authentication

## Checklist
- [ ] Docs build locally (`npm run build`)
- [ ] Spelling/formatting checked
- [ ] Assign reviewers

Notes:
- Some examples are marked `*(inferred — verify)*`. Please confirm those during review.
