### PR TITLE
Docs auth final

### DIFF
--- a/docs/docs/auth/auth_module_docs.md
+++ b/docs/docs/auth/auth_module_docs.md
@@ -1,0 +1,162 @@
+---
+slug: /auth
+title: Authentication (Auth)
+description: Centralized authentication and authorization integration for Midil services. Includes support for AWS Cognito, JWT verification, and pluggable authentication providers.
+---
+
+# Authentication (Auth)
+
+## Overview
+The `auth` module provides a unified authentication and authorization framework for all Midil services. It enables seamless integration with **AWS Cognito** for both **client credentials authentication** (for outbound requests) and **JWT-based authorization** (for inbound requests). This ensures that only verified users and services interact securely across the Midil ecosystem.
+
+The module is designed for developers and service integrators who want to easily enable authentication without deep technical understanding of the underlying security mechanisms.
+
+---
+
+## How It Fits Into Midil
+Authentication sits at the heart of Midil’s security layer. Every inbound request is verified through JWT tokens, while outbound service-to-service calls use secure client credentials to fetch access tokens. The `auth` module standardizes this process, making it simple and consistent across all microservices.
+
+**Inbound flow:**
+- Verifies incoming JWTs using AWS Cognito public keys.
+- Ensures tokens are valid, signed, and scoped correctly.
+
+**Outbound flow:**
+- Generates and caches access tokens using Cognito’s client credentials grant flow.
+- Automatically attaches tokens to outgoing HTTP requests.
+
+---
+
+## Key Components
+
+| File / Submodule | Purpose |
+|------------------|----------|
+| `cognito/` | Handles Cognito authentication and JWT validation. |
+| `interfaces/` | Defines abstract interfaces for authentication and authorization providers. |
+| `config.py` | Stores configuration models for auth settings (client ID, secret, token URL, etc.). |
+| `exceptions.py` | Custom errors raised during authentication or authorization failures. |
+| `middlewares/` | FastAPI middleware for easy JWT verification in HTTP APIs. |
+| `utils.py` | Helper utilities for token parsing and validation. |
+
+---
+
+## Quick Start
+
+### Installation
+Make sure the Midil SDK is installed in your project:
+
+```bash
+pip install midil-kit[auth]
+```
+
+### Example 1: Outbound Authentication (Client Credentials)
+Authenticate your service when calling another Midil service.
+
+```python
+from midil.auth.cognito import CognitoClientCredentialsAuthenticator
+
+auth_client = CognitoClientCredentialsAuthenticator(
+    client_id="COGNITO_CLIENT_ID",              # *(inferred — verify)*
+    client_secret="<REDACTED>",
+    token_url="https://<your-domain>.auth.<region>.amazoncognito.com/oauth2/token",
+)
+
+token = await auth_client.get_token()
+headers = await auth_client.get_headers()
+# Use headers in your outbound HTTP request
+```
+
+### Example 2: Inbound Authentication (JWT Middleware)
+Secure your FastAPI application with Cognito JWT verification.
+
+```python
+from fastapi import FastAPI
+from midil.auth.cognito import CognitoJWTAuthorizer
+from midil.midilapi.fastapi.middleware.auth_middleware import CognitoAuthMiddleware
+
+app = FastAPI()
+
+# Add the JWT verification middleware
+app.add_middleware(CognitoAuthMiddleware, authorizer=CognitoJWTAuthorizer(...))
+```
+
+---
+
+## Configuration
+The `auth` module uses environment variables or configuration files to securely store credentials.
+
+| Key | Description |
+|-----|--------------|
+| `COGNITO_CLIENT_ID` | The Cognito app client ID used for authentication. |
+| `COGNITO_CLIENT_SECRET` | Secret key for the Cognito app client. |
+| `COGNITO_DOMAIN` | Base domain for your Cognito user pool. |
+| `COGNITO_REGION` | AWS region where your user pool is hosted. |
+| `COGNITO_USER_POOL_ID` | Identifier for your user pool. |
+
+> **Tip:** Use environment variables or a secrets manager—never store credentials directly in code or repositories.
+
+---
+
+## Error Handling
+Common exceptions include:
+
+- `AuthenticationError` – Raised when authentication fails (e.g., invalid credentials).
+- `AuthorizationError` – Raised when a user lacks permission to access a resource.
+- `CognitoAuthenticationError` – AWS Cognito token generation failed.
+- `CognitoAuthorizationError` – Token verification failed (invalid signature or audience).
+
+You can handle these errors gracefully in FastAPI:
+
+```python
+from midil.auth.exceptions import AuthenticationError
+from fastapi import HTTPException
+
+try:
+    await auth_client.get_token()
+except AuthenticationError:
+    raise HTTPException(status_code=401, detail="Unauthorized")
+```
+
+---
+
+## Security & Best Practices
+- Always use HTTPS for token exchange.
+- Use AWS Secrets Manager or similar for storing sensitive values.
+- Validate token audience (`aud`) and issuer (`iss`).
+- Rotate credentials regularly.
+- Ensure system clocks are synchronized (for token expiry accuracy).
+
+---
+
+## Integrations & References
+- **AWS Cognito Documentation:** [https://docs.aws.amazon.com/cognito](https://docs.aws.amazon.com/cognito)
+- **FastAPI Middleware:** [https://fastapi.tiangolo.com/tutorial/middleware/](https://fastapi.tiangolo.com/tutorial/middleware/)
+- **JWT Introduction:** [https://jwt.io/introduction](https://jwt.io/introduction)
+
+---
+
+## Troubleshooting
+| Issue | Cause | Solution |
+|--------|--------|-----------|
+| 401 Unauthorized | Invalid token or expired credentials | Regenerate tokens or verify Cognito setup |
+| 403 Forbidden | Token lacks required permissions | Check scopes or user group mappings |
+| InvalidSignatureError | Wrong JWKS endpoint or mismatched keys | Ensure correct Cognito region and pool ID |
+
+---
+
+## Maintainers
+**Midil Labs Security & Platform Team**  
+Contact: [security@midil.io](mailto:security@midil.io)
+
+---
+
+## Appendix: Key Classes
+| Class | Description |
+|--------|--------------|
+| `CognitoClientCredentialsAuthenticator` | Fetches access tokens for outbound API calls. |
+| `CognitoJWTAuthorizer` | Validates incoming JWTs using Cognito’s public keys. |
+| `AuthConfig` | Central configuration for authentication parameters. |
+| `AuthenticationError`, `AuthorizationError` | Standard error classes used across the module. |
+
+---
+*Last updated: October 2025*
+

--- a/docs/docs/auth_documentation.md
+++ b/docs/docs/auth_documentation.md
@@ -1,0 +1,145 @@
+# Midil Auth Module Documentation
+
+## Overview
+The **Midil Auth Module** provides a unified authentication layer for securing APIs and microservices within the Midil Kit ecosystem. It ensures secure access control through **token-based authentication**, with **AWS Cognito** as the default provider. The module is flexible and can be extended to integrate with other authentication strategies (e.g., OAuth2, Firebase, or custom JWT solutions).
+
+---
+
+## Core Features
+- **Plug-and-Play Authentication Middleware** for FastAPI.
+- **Built-in Cognito Integration** for AWS-based deployments.
+- **Custom Strategy Support** – easily extendable for any identity provider.
+- **JWT Authorization** and Token Validation.
+- **Secure Configuration via Environment Variables.**
+
+---
+
+## Configuration Setup
+
+The `config.py` defines a `CognitoAuthConfig` model:
+```python
+class CognitoAuthConfig(BaseModel):
+    type: Literal["cognito"] = "cognito"
+    user_pool_id: str
+    client_id: str
+    client_secret: Optional[SecretStr]
+    region: str
+```
+
+In your `.env` file:
+```bash
+MIDIL__AUTH={
+  "type": "cognito",
+  "user_pool_id": "us-east-1_abcdef123",
+  "client_id": "1234567890abcdef",
+  "region": "us-east-1",
+  "client_secret": null
+}
+```
+
+> ⚙️ **Tip:** Always ensure your `.env` values match the AWS Cognito pool configuration or equivalent provider setup.
+
+---
+
+## Implementation Guide (Step-by-Step)
+
+1. **Import the Middleware and Authorizer**:
+   ```python
+   from midil.auth.cognito import CognitoJWTAuthorizer
+   from midil.midilapi.fastapi.middleware.auth_middleware import CognitoAuthMiddleware
+   ```
+
+2. **Add the Middleware to FastAPI**:
+   ```python
+   app.add_middleware(
+       CognitoAuthMiddleware,
+       authorizer=CognitoJWTAuthorizer(region="us-east-1", user_pool_id="us-east-1_abcdef123")
+   )
+   ```
+
+3. **Protect Your Routes**:
+   ```python
+   from fastapi import Depends, FastAPI
+   from midil.auth.dependencies import get_current_user
+
+   app = FastAPI()
+
+   @app.get("/profile")
+   def profile(user: dict = Depends(get_current_user)):
+       return {"message": f"Welcome {user['username']}"}
+   ```
+
+4. **Run and Test**:
+   - Start the server and test with an Authorization header:
+     ```bash
+     curl -H "Authorization: Bearer <JWT_TOKEN>" http://localhost:8000/profile
+     ```
+
+---
+
+## Cognito Authentication Flow
+
+The Cognito-based flow works as follows:
+
+1. A user logs in via Cognito and receives a JWT access token.
+2. The client app includes this token in the `Authorization` header.
+3. The `CognitoAuthMiddleware` intercepts the request.
+4. The `CognitoJWTAuthorizer` verifies the token using Cognito's public keys.
+5. The request is passed downstream only if verified.
+
+**Simplified Architecture Diagram:**
+```
+Client App --> FastAPI + CognitoAuthMiddleware --> CognitoJWTAuthorizer --> AWS Cognito (Public Keys)
+```
+
+---
+
+## Extending Authentication (Custom Strategies)
+
+You can build your own strategy by subclassing the base authentication provider:
+```python
+from midil.auth.base import AuthZProvider
+
+class CustomJWTAuthorizer(AuthZProvider):
+    def verify_token(self, token: str):
+        # Custom logic here (e.g., Firebase, Auth0, or internal system)
+        return {"username": "custom_user", "roles": ["admin"]}
+```
+
+Then update your `.env`:
+```bash
+MIDIL__AUTH={"type": "custom"}
+```
+
+> 💡 **Note:** Midil is designed to make adding new authentication types straightforward—just implement a compatible provider and update the config.
+
+---
+
+## Testing & Troubleshooting
+
+### Test Authentication
+Use Postman or `curl` to send a request with a valid JWT:
+```bash
+curl -H "Authorization: Bearer <valid_token>" http://localhost:8000/profile
+```
+If successful, you’ll receive a JSON response with the authenticated user info.
+
+### Common Errors
+| Status | Cause | Resolution |
+|--------|--------|------------|
+| `401 Unauthorized` | Invalid or missing token | Ensure a valid JWT is sent. |
+| `403 Forbidden` | User lacks permission | Check user roles and access policies. |
+| `500 Internal Server Error` | Invalid Cognito config | Verify `.env` and Cognito setup. |
+
+---
+
+## Summary
+The **Midil Auth Module** simplifies secure authentication across services. With AWS Cognito as its default provider, it offers a plug-and-play experience for token-based security. Developers can easily swap or extend authentication strategies while keeping the same middleware architecture.
+
+---
+
+**Next Steps:**
+- Refer to AWS Cognito Documentation: [AWS Cognito Developer Guide](https://docs.aws.amazon.com/cognito/latest/developerguide/what-is-amazon-cognito.html)
+- Explore `midil.auth.base` to create custom authenticators.
+- Integrate authentication into event consumers or HTTP clients for full-stack consistency.
+


### PR DESCRIPTION
## Summary
Add a consolidated authentication guide for Midil (Cognito usage, configuration, extension guide, troubleshooting).

### What this includes
- Single consolidated doc: `docs/docs/auth/auth_documentation.md`
- Cognito implementation guide (outbound client-credentials + inbound JWT verification)
- Configuration examples (env/JSON)
- Developer checklist for adding new auth providers
- Troubleshooting and security notes

### Notes
Some strings in the doc are marked `*(inferred — verify)*` and should be confirmed by maintainers (middleware import path and any project-specific env var names).

Please review and merge into `docs` when ready.
